### PR TITLE
Support for gjs 1.71.1 and gnome-shell 42

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -35,6 +35,10 @@ const Mainloop = imports.mainloop;
 
 const Config = imports.misc.config;
 const AppDisplay = imports.ui.appDisplay;
+const AppMenu = imports.ui.appMenu;
+if (Config.PACKAGE_VERSION < '42') {
+const AppMenu = imports.ui.appDisplay;
+}
 const AppFavorites = imports.ui.appFavorites;
 const Dash = imports.ui.dash;
 const DND = imports.ui.dnd;
@@ -1456,7 +1460,7 @@ function getIconPadding(monitorIndex) {
 
  var taskbarSecondaryMenu = Utils.defineClass({
     Name: 'DashToPanel.SecondaryMenu',
-    Extends: AppDisplay.AppMenu,
+    Extends: AppMenu.AppMenu,
     ParentConstrParams: [[0], [1]],
 
     _init: function(source, side) {

--- a/intellihide.js
+++ b/intellihide.js
@@ -335,7 +335,7 @@ var Intellihide = Utils.defineClass({
     },
 
     _checkIfGrab: function() {
-        if (GrabHelper._grabHelperStack.some(gh => gh._owner == this._dtpPanel.panel.actor)) {
+        if (GrabHelper._grabHelperStack && GrabHelper._grabHelperStack.some(gh => gh._owner == this._dtpPanel.panel.actor)) {
             //there currently is a grab on a child of the panel, check again soon to catch its release
             this._timeoutsHandler.add([T1, CHECK_GRAB_MS, () => this._queueUpdatePanelPosition()]);
 

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
 "uuid": "dash-to-panel@jderose9.github.com",
 "name": "Dash to Panel",
 "description": "An icon taskbar for the Gnome Shell. This extension moves the dash into the gnome main panel so that the application launchers and system tray are combined into a single panel, similar to that found in KDE Plasma and Windows 7+. A separate dock is no longer needed for easy access to running and favorited applications.\n\nFor a more traditional experience, you may also want to use Tweak Tool to enable Windows > Titlebar Buttons > Minimize & Maximize.\n\nFor the best support, please report any issues on Github. Dash-to-panel is developed and maintained by @jderose9 and @charlesg99.",
-"shell-version": [ "41" ],
+"shell-version": [ "41", "42" ],
 "url": "https://github.com/jderose9/dash-to-panel",
 "gettext-domain": "dash-to-panel",
 "version": 9999

--- a/overview.js
+++ b/overview.js
@@ -589,8 +589,9 @@ var dtpOverview = Utils.defineClass({
                     workAreaBox.set_origin(startX, startY);
                     workAreaBox.set_size(workArea.width, workArea.height);
     
-                    params = [workAreaBox, searchHeight, dashHeight, workspaceAppGridBox]
-                    if (Config.PACKAGE_VERSION > '42.beta') {
+                    if (Config.PACKAGE_VERSION < '42') {
+                        params = [workAreaBox, searchHeight, dashHeight, workspaceAppGridBox]
+                    } else {
                         params = [box, workAreaBox, searchHeight, dashHeight, workspaceAppGridBox]
                     }
                 } else {

--- a/overview.js
+++ b/overview.js
@@ -590,6 +590,9 @@ var dtpOverview = Utils.defineClass({
                     workAreaBox.set_size(workArea.width, workArea.height);
     
                     params = [workAreaBox, searchHeight, dashHeight, workspaceAppGridBox]
+                    if (Config.PACKAGE_VERSION > '42.beta') {
+                        params = [box, workAreaBox, searchHeight, dashHeight, workspaceAppGridBox]
+                    }
                 } else {
                     params = [box, startX, searchHeight, dashHeight, workspaceAppGridBox];
                 }

--- a/panel.js
+++ b/panel.js
@@ -204,8 +204,10 @@ var dtpPanel = Utils.defineClass({
         let isTop = this.geom.position == St.Side.TOP;
 
         if (isTop) {
-            this.panel._leftCorner = this.panel._leftCorner || new Panel.PanelCorner(St.Side.LEFT);
-            this.panel._rightCorner = this.panel._rightCorner || new Panel.PanelCorner(St.Side.RIGHT);
+            if (Config.PACKAGE_VERSION < '42') {
+                this.panel._leftCorner = this.panel._leftCorner || new Panel.PanelCorner(St.Side.LEFT);
+                this.panel._rightCorner = this.panel._rightCorner || new Panel.PanelCorner(St.Side.RIGHT);
+            }
 
             Main.overview._overview.insert_child_at_index(this._myPanelGhost, 0);
         } else {

--- a/panelManager.js
+++ b/panelManager.js
@@ -682,7 +682,7 @@ function newUpdateHotCorners() {
         if (haveTopLeftCorner) {
             let corner = new Layout.HotCorner(this, monitor, cornerX, cornerY);
 
-            corner.setBarrierSize = size => corner.__proto__.setBarrierSize.call(corner, Math.min(size, 32));
+            corner.setBarrierSize = size => Object.getPrototypeOf(corner).setBarrierSize.call(corner, Math.min(size, 32));
             corner.setBarrierSize(panel ? panel.dtpSize : 32);
             this.hotCorners.push(corner);
         } else {

--- a/prefs.js
+++ b/prefs.js
@@ -26,8 +26,10 @@ const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Gdk = imports.gi.Gdk;
+const Adw = imports.gi.Adw;
 const Lang = imports.lang;
 const Mainloop = imports.mainloop;
+const Config = imports.misc.config;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
@@ -2457,6 +2459,16 @@ const BuilderScope = GObject.registerClass({
 
 function init() {
     Convenience.initTranslations();
+}
+
+function fillPreferencesWindow(window) {
+    window.set_default_size(680, 740);
+
+    let preferences = new Preferences();
+    let box = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL});
+    box.append(new Adw.HeaderBar);
+    box.append(preferences.notebook);
+    window.set_content(box);
 }
 
 function buildPrefsWidget() {

--- a/taskbar.js
+++ b/taskbar.js
@@ -1236,19 +1236,9 @@ var taskbar = Utils.defineClass({
                     };
                 }
 
-                // force spring animation triggering.By default the animation only
-                // runs if we are already inside the overview.
+                // force exiting overview if needed
                 if (!Main.overview._shown) {
                     this.forcedOverview = true;
-                    let grid = AppDisplay._grid;
-                    let onShownCb;
-                    let overviewSignal = Config.PACKAGE_VERSION > '3.38.1' ? 'showing' : 'shown';
-                    let overviewShowingId = Main.overview.connect(overviewSignal, () => {
-                        Main.overview.disconnect(overviewShowingId);
-                        onShownCb();
-                    });
-
-                    onShownCb = () => grid.emit('animation-done');
                 }
 
                 //temporarily use as primary the monitor on which the showapps btn was clicked, this is

--- a/taskbar.js
+++ b/taskbar.js
@@ -1232,7 +1232,7 @@ var taskbar = Utils.defineClass({
                             return Clutter.EVENT_STOP;
                         }
     
-                        return this.__proto__._onStageKeyPress.call(this, actor, event);
+                        return Object.getPrototypeOf(this)._onStageKeyPress.call(this, actor, event);
                     };
                 }
 

--- a/transparency.js
+++ b/transparency.js
@@ -21,6 +21,7 @@ const Lang = imports.lang;
 const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
 const St = imports.gi.St;
+const Config = imports.misc.config;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Panel = Me.imports.panel;
@@ -39,6 +40,10 @@ var DynamicTransparency = Utils.defineClass({
 
         this._initialPanelStyle = dtpPanel.panel.actor.get_style();
         
+        if (Config.PACKAGE_VERSION < '42' && this._dtpPanel.geom.position == St.Side.TOP) {
+            this._initialPanelCornerStyle = dtpPanel.panel._leftCorner.actor.get_style();
+        }
+
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._bindSignals();
 
@@ -52,6 +57,11 @@ var DynamicTransparency = Utils.defineClass({
         this._proximityManager.removeWatch(this._proximityWatchId);
 
         this._dtpPanel.panel.actor.set_style(this._initialPanelStyle);
+        
+        if (Config.PACKAGE_VERSION < '42' && this._dtpPanel.geom.position == St.Side.TOP) {
+            this._dtpPanel.panel._leftCorner.actor.set_style(this._initialPanelCornerStyle);
+            this._dtpPanel.panel._rightCorner.actor.set_style(this._initialPanelCornerStyle);
+        }
     },
 
     updateExternalStyle: function() {
@@ -211,6 +221,12 @@ var DynamicTransparency = Utils.defineClass({
         let transition = 'transition-duration:' + this.animationDuration;
 
         this._dtpPanel.set_style('background-color: ' + this.currentBackgroundColor + transition + this._complementaryStyles);
+        
+        if (Config.PACKAGE_VERSION < '42' && this._dtpPanel.geom.position == St.Side.TOP) {
+            let cornerStyle = '-panel-corner-background-color: ' + this.currentBackgroundColor + transition;
+            this._dtpPanel.panel._leftCorner.actor.set_style(cornerStyle);
+            this._dtpPanel.panel._rightCorner.actor.set_style(cornerStyle);
+        }
     },
 
     _setGradient: function() {

--- a/transparency.js
+++ b/transparency.js
@@ -39,10 +39,6 @@ var DynamicTransparency = Utils.defineClass({
 
         this._initialPanelStyle = dtpPanel.panel.actor.get_style();
         
-        if (this._dtpPanel.geom.position == St.Side.TOP) {
-            this._initialPanelCornerStyle = dtpPanel.panel._leftCorner.actor.get_style();
-        }
-
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._bindSignals();
 
@@ -56,11 +52,6 @@ var DynamicTransparency = Utils.defineClass({
         this._proximityManager.removeWatch(this._proximityWatchId);
 
         this._dtpPanel.panel.actor.set_style(this._initialPanelStyle);
-        
-        if (this._dtpPanel.geom.position == St.Side.TOP) {
-            this._dtpPanel.panel._leftCorner.actor.set_style(this._initialPanelCornerStyle);
-            this._dtpPanel.panel._rightCorner.actor.set_style(this._initialPanelCornerStyle);
-        }
     },
 
     updateExternalStyle: function() {
@@ -218,14 +209,8 @@ var DynamicTransparency = Utils.defineClass({
         this.currentBackgroundColor = Utils.getrgbaColor(this.backgroundColorRgb, this.alpha);
 
         let transition = 'transition-duration:' + this.animationDuration;
-        let cornerStyle = '-panel-corner-background-color: ' + this.currentBackgroundColor + transition;
 
         this._dtpPanel.set_style('background-color: ' + this.currentBackgroundColor + transition + this._complementaryStyles);
-        
-        if (this._dtpPanel.geom.position == St.Side.TOP) {
-            this._dtpPanel.panel._leftCorner.actor.set_style(cornerStyle);
-            this._dtpPanel.panel._rightCorner.actor.set_style(cornerStyle);
-        }
     },
 
     _setGradient: function() {

--- a/utils.js
+++ b/utils.js
@@ -358,10 +358,10 @@ var mergeObjects = function(main, bck) {
 
 var hookVfunc = function(proto, symbol, func) {
     if (Gi.hook_up_vfunc_symbol && func) {
-        if (Config.PACKAGE_VERSION < '42') {
-            proto[Gi.hook_up_vfunc_symbol](symbol, func);
-        } else {
-            proto[Gi.gobject_prototype_symbol][Gi.hook_up_vfunc_symbol](symbol, func);
+        try {
+            proto[Gi.gobject_prototype_symbol][Gi.hook_up_vfunc_symbol] (symbol, func);
+        } catch (e) {
+            proto[Gi.hook_up_vfunc_symbol] (symbol, func);
         }
     }
 };

--- a/utils.js
+++ b/utils.js
@@ -80,19 +80,31 @@ var defineClass = function (classDef) {
         return parentArgs;
     };
     
-    let C = eval(
-        '(class C ' + (needsSuper ? 'extends Object' : '') + ' { ' +
-        '     constructor(...args) { ' +
-                  (needsSuper ? 'super(...getParentArgs(args));' : '') +
-                  (needsSuper || !parentProto ? 'this._init(...args);' : '') +
-        '     }' +
-        '     callParent(...args) { ' +
-        '         let func = args.shift(); ' +
-        '         if (!(func === \'_init\' && needsSuper))' +
-        '             super[func](...args); ' +
-        '     }' +    
-        '})'
-    );
+    let C;
+    if (isGObject) {
+        C = eval(
+            '(class C extends GObject.Object { ' +
+            '     callParent(...args) { ' +
+            '         let func = args.shift(); ' +
+            '         super[func](...args); ' +
+            '     }' +
+            '})'
+        );
+    } else {
+        C = eval(
+            '(class C ' + (needsSuper ? 'extends Object' : '') + ' { ' +
+            '     constructor(...args) { ' +
+                    (needsSuper ? 'super(...getParentArgs(args));' : '') +
+                    (needsSuper || !parentProto ? 'this._init(...args);' : '') +
+            '     }' +
+            '     callParent(...args) { ' +
+            '         let func = args.shift(); ' +
+            '         if (!(func === \'_init\' && needsSuper))' +
+            '             super[func](...args); ' +
+            '     }' +    
+            '})'
+        );
+    }
 
     if (parentProto) {
         Object.setPrototypeOf(C.prototype, parentProto);
@@ -347,7 +359,8 @@ var mergeObjects = function(main, bck) {
 var hookVfunc = function(proto, symbol, func) {
     if (Gi.hook_up_vfunc_symbol && func) {
         //gjs > 1.53.3
-        proto[Gi.hook_up_vfunc_symbol](symbol, func);
+        // todo
+        //proto[Gi.hook_up_vfunc_symbol](symbol, func);
     } else {
         //On older gjs, this is how to hook vfunc. It is buggy and can't be used reliably to replace
         //already hooked functions. Since it's our only use for it, disabled for now (and probably forever) 

--- a/utils.js
+++ b/utils.js
@@ -358,12 +358,11 @@ var mergeObjects = function(main, bck) {
 
 var hookVfunc = function(proto, symbol, func) {
     if (Gi.hook_up_vfunc_symbol && func) {
-        //gjs > 1.53.3
-        proto[Gi.gobject_prototype_symbol][Gi.hook_up_vfunc_symbol](symbol, func);
-    } else {
-        //On older gjs, this is how to hook vfunc. It is buggy and can't be used reliably to replace
-        //already hooked functions. Since it's our only use for it, disabled for now (and probably forever) 
-        //Gi.hook_up_vfunc(proto, symbol, func);
+        if (Config.PACKAGE_VERSION < '42') {
+            proto[Gi.hook_up_vfunc_symbol](symbol, func);
+        } else {
+            proto[Gi.gobject_prototype_symbol][Gi.hook_up_vfunc_symbol](symbol, func);
+        }
     }
 };
 

--- a/utils.js
+++ b/utils.js
@@ -359,8 +359,7 @@ var mergeObjects = function(main, bck) {
 var hookVfunc = function(proto, symbol, func) {
     if (Gi.hook_up_vfunc_symbol && func) {
         //gjs > 1.53.3
-        // todo
-        //proto[Gi.hook_up_vfunc_symbol](symbol, func);
+        proto[Gi.gobject_prototype_symbol][Gi.hook_up_vfunc_symbol](symbol, func);
     } else {
         //On older gjs, this is how to hook vfunc. It is buggy and can't be used reliably to replace
         //already hooked functions. Since it's our only use for it, disabled for now (and probably forever) 
@@ -389,7 +388,7 @@ var getTransformedAllocation = function(actor) {
 };
 
 var allocate = function(actor, box, flags, useParent) {
-    let allocateObj = useParent ? actor.__proto__ : actor;
+    let allocateObj = useParent ? Object.getPrototypeOf(actor) : actor;
 
     allocateObj.allocate.apply(actor, getAllocationParams(box, flags));
 };


### PR DESCRIPTION
Makes dtp work with gnome 42 and keeps backwards compatibility with gnome 41.
https://github.com/home-sweet-gnome/dash-to-panel/pull/1584